### PR TITLE
bring log level for command output down to debug

### DIFF
--- a/lib/logger_pipe/runner.rb
+++ b/lib/logger_pipe/runner.rb
@@ -40,7 +40,7 @@ module LoggerPipe
             pid = com.pid
             while line = com.gets
               buf << line
-              logger.info(line.chomp)
+              logger.debug(line.chomp)
             end
           end
           if $?.exitstatus == 0


### PR DESCRIPTION
too much info log for query command result like `gcloud compute instances`
## reviewers
- [x] @nagachika 
