### PR TITLE
add :returns and :logging options

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,2 @@
---format documentation
+--format Fuubar
 --color

--- a/lib/logger_pipe.rb
+++ b/lib/logger_pipe.rb
@@ -3,7 +3,7 @@ require "logger_pipe/version"
 module LoggerPipe
   autoload :Runner, "logger_pipe/runner"
 
-  SOURCES = [:nil, :stdout, :stderr, :both].freeze
+  SOURCES = [:none, :stdout, :stderr, :both].freeze
 
   class << self
     # run
@@ -12,8 +12,8 @@ module LoggerPipe
     # @param [Hash] options
     # @option options [Integer] :timeout Seconds, default is nil.
     # @option options [true|false] :dry_run If true given, command is not run actually
-    # @option options [Symbol] :returns Which output is used as return, one of :nil, :stdout, :stderr, :both
-    # @option options [Symbol] :logging Which output is written to logger, one of :nil, :stdout, :stderr, :both
+    # @option options [Symbol] :returns Which output is used as return, one of :none, :stdout, :stderr, :both
+    # @option options [Symbol] :logging Which output is written to logger, one of :none, :stdout, :stderr, :both
     def run(logger, cmd, options = {})
       Runner.new(logger, cmd, options).execute
     end

--- a/lib/logger_pipe.rb
+++ b/lib/logger_pipe.rb
@@ -3,7 +3,17 @@ require "logger_pipe/version"
 module LoggerPipe
   autoload :Runner, "logger_pipe/runner"
 
+  SOURCES = [:nil, :stdout, :stderr, :both].freeze
+
   class << self
+    # run
+    # @param [Logger] logger
+    # @param [String] cmd Command to run on shell
+    # @param [Hash] options
+    # @option options [Integer] :timeout Seconds, default is nil.
+    # @option options [true|false] :dry_run If true given, command is not run actually
+    # @option options [Symbol] :returns Which output is used as return, one of :nil, :stdout, :stderr, :both
+    # @option options [Symbol] :logging Which output is written to logger, one of :nil, :stdout, :stderr, :both
     def run(logger, cmd, options = {})
       Runner.new(logger, cmd, options).execute
     end

--- a/lib/logger_pipe/runner.rb
+++ b/lib/logger_pipe/runner.rb
@@ -112,16 +112,8 @@ module LoggerPipe
           f.close
           actual_cmd =
             case returns
-            when :stdout then
-              case logging
-              when :stderr then "#{cmd} 2>#{f.path}"
-              when :both   then "#{cmd} 2>#{f.path}"
-              end
-            when :stderr then
-              case logging
-              when :stdout then "#{cmd} 2>&1 1>#{f.path}"
-              when :both   then "#{cmd} 2>&1 1>#{f.path}"
-              end
+            when :stdout then "#{cmd} 2>#{f.path}"
+            when :stderr then "#{cmd} 2>&1 1>#{f.path}"
             end
           begin
             return block_given? ? yield(actual_cmd, logging == :both) : nil

--- a/lib/logger_pipe/runner.rb
+++ b/lib/logger_pipe/runner.rb
@@ -21,6 +21,8 @@ module LoggerPipe
       @logger, @cmd = logger, cmd
       @timeout = options[:timeout]
       @dry_run = options[:dry_run]
+      @return_from = options[:returns] || :stdout # :nil, :stdout, :stderr, :both
+      @logging_from = options[:logging] || :both # :nil, :stdout, :stderr, :both
     end
 
     def execute

--- a/lib/logger_pipe/runner.rb
+++ b/lib/logger_pipe/runner.rb
@@ -23,7 +23,7 @@ module LoggerPipe
       @timeout = options[:timeout]
       @dry_run = options[:dry_run]
       @returns = options[:returns] || :stdout # :nil, :stdout, :stderr, :both
-      @logging = options[:logging] || :both # :nil, :stdout, :stderr, :both
+      @logging = options[:logging] || :both   # :nil, :stdout, :stderr, :both
     end
 
     def execute
@@ -90,6 +90,8 @@ module LoggerPipe
     end
 
     def setup
+      raise ArgumentError, "Invalid option :returns #{returns.inspect}" unless SOURCES.include?(returns)
+      raise ArgumentError, "Invalid option :logging #{logging.inspect}" unless SOURCES.include?(logging)
       if (returns == :both) && ([:stdout, :stderr].include?(logging))
         raise ArgumentError, "Can' set logging: #{logging.inspect} with returns: #{returns.inspect}"
       elsif (returns == :nil) || (logging == :nil) || (returns == logging)

--- a/lib/logger_pipe/runner.rb
+++ b/lib/logger_pipe/runner.rb
@@ -22,8 +22,8 @@ module LoggerPipe
       @logger, @cmd = logger, cmd
       @timeout = options[:timeout]
       @dry_run = options[:dry_run]
-      @returns = options[:returns] || :stdout # :nil, :stdout, :stderr, :both
-      @logging = options[:logging] || :both   # :nil, :stdout, :stderr, :both
+      @returns = options[:returns] || :stdout # :none, :stdout, :stderr, :both
+      @logging = options[:logging] || :both   # :none, :stdout, :stderr, :both
     end
 
     def execute
@@ -50,7 +50,7 @@ module LoggerPipe
           end
           if $?.exitstatus == 0
             logger.info("\e[32mSUCCESS: %s\e[0m" % [actual_cmd])
-            return (returns == :nil) ? nil : @buf.join
+            return (returns == :none) ? nil : @buf.join
           else
             msg = "\e[31mFAILURE: %s\e[0m" % [actual_cmd]
             logger.error(msg)
@@ -94,12 +94,12 @@ module LoggerPipe
       raise ArgumentError, "Invalid option :logging #{logging.inspect}" unless SOURCES.include?(logging)
       if (returns == :both) && ([:stdout, :stderr].include?(logging))
         raise ArgumentError, "Can' set logging: #{logging.inspect} with returns: #{returns.inspect}"
-      elsif (returns == :nil) || (logging == :nil) || (returns == logging)
+      elsif (returns == :none) || (logging == :none) || (returns == logging)
         actual_cmd =
           case logging
-          when :nil    then
+          when :none    then
             case returns
-            when :nil    then "#{cmd} 1>/dev/null 2>/dev/null"
+            when :none   then "#{cmd} 1>/dev/null 2>/dev/null"
             when :stdout then "#{cmd} 2>/dev/null"
             when :stderr then "#{cmd} 2>&1 1>/dev/null"
             when :both   then "#{cmd} 2>&1"
@@ -108,7 +108,7 @@ module LoggerPipe
           when :stderr then "#{cmd} 2>&1 1>/dev/null"
           when :both   then "#{cmd} 2>&1"
           end
-        return block_given? ? yield(actual_cmd, logging != :nil) : nil
+        return block_given? ? yield(actual_cmd, logging != :none) : nil
       else
         Tempfile.open("logger_pipe.stderr.log") do |f|
           f.close

--- a/lib/logger_pipe/runner.rb
+++ b/lib/logger_pipe/runner.rb
@@ -126,10 +126,7 @@ module LoggerPipe
 
     def logging_subfile(f)
       f.open
-      c = f.read
-      if !c.nil? && !c.empty?
-        logger.info("--- begin stderr ---\n#{c}\n--- end stderr ---")
-      end
+      logger.info("--- begin stderr ---\n%s\n--- end stderr ---" % f.read)
     end
   end
 

--- a/lib/logger_pipe/version.rb
+++ b/lib/logger_pipe/version.rb
@@ -1,3 +1,3 @@
 module LoggerPipe
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end

--- a/spec/logger_pipe_spec.rb
+++ b/spec/logger_pipe_spec.rb
@@ -56,8 +56,9 @@ describe LoggerPipe do
       end
     end
 
-    context ":return and :logging" do
+    context ":returns and :logging" do
       {
+        # [:returns, :logging] => [return of LoggerPipe.run, logging expectations]
         [:nil   , :nil   ] => [nil              , {foo: false, bar: false, baz: false}], # OK
         [:nil   , :stdout] => [nil              , {foo: true , bar: false, baz: true }], # OK
         [:nil   , :stderr] => [nil              , {foo: false, bar: true , baz: false}], # OK

--- a/spec/logger_pipe_spec.rb
+++ b/spec/logger_pipe_spec.rb
@@ -30,7 +30,7 @@ describe LoggerPipe do
       it "logging output" do
         LoggerPipe.run(logger, cmd)
         msg = buffer.string
-        expect(msg.lines.length).to eq 4
+        expect(msg.lines.length).to be >= 4
         expect(msg.lines[0]).to match /executing: #{Regexp.escape(cmd)}/
         expect(msg.lines[1]).to match /Foo: /
         expect(msg.lines[2]).to match /Bar: /
@@ -108,7 +108,7 @@ describe LoggerPipe do
       end
     end
 
-    
+
     context "dry_run: true" do
       let(:cmd){ "date +'Foo: %Y-%m-%dT%H:%M:%S'; sleep 1; date +'Bar: %Y-%m-%dT%H:%M:%S'" }
       it "returns nil" do
@@ -134,7 +134,7 @@ describe LoggerPipe do
       it "failure" do
         LoggerPipe.run(logger, cmd) rescue nil
         msg = buffer.string
-        expect(msg.lines.length).to eq 3
+        expect(msg.lines.length).to be >= 3
         expect(msg.lines[0]).to match /executing: #{Regexp.escape(cmd)}/
         expect(msg.lines[1]).to match /Foo: /
         expect(msg.lines[2]).to match /FAILURE: date \+'Foo: /

--- a/spec/logger_pipe_spec.rb
+++ b/spec/logger_pipe_spec.rb
@@ -72,6 +72,8 @@ describe LoggerPipe do
         [:stderr, :stderr] => ["bar\n"          , {foo: false, bar: true , baz: false}], # BINGO
         [:stderr, :both  ] => ["bar\n"          , {foo: true , bar: true , baz: true }], # NOT REALTIME
         [:both  , :nil   ] => ["foo\nbar\nbaz\n", {foo: false, bar: false, baz: false}], # OK
+        [:wrong , :nil   ] => :invalid,
+        [:nil   , :wrong ] => :invalid,
         [:both  , :stdout] => :invalid,
         [:both  , :stderr] => :invalid,
         [:both  , :both  ] => ["foo\nbar\nbaz\n", {foo: true , bar: true , baz: true }], # BINGO

--- a/spec/logger_pipe_spec.rb
+++ b/spec/logger_pipe_spec.rb
@@ -59,21 +59,21 @@ describe LoggerPipe do
     context ":returns and :logging" do
       {
         # [:returns, :logging] => [return of LoggerPipe.run, logging expectations]
-        [:nil   , :nil   ] => [nil              , {foo: false, bar: false, baz: false}], # OK
-        [:nil   , :stdout] => [nil              , {foo: true , bar: false, baz: true }], # OK
-        [:nil   , :stderr] => [nil              , {foo: false, bar: true , baz: false}], # OK
-        [:nil   , :both  ] => [nil              , {foo: true , bar: true , baz: true }], # OK
-        [:stdout, :nil   ] => ["foo\nbaz\n"     , {foo: false, bar: false, baz: false}], # OK
+        [:none  , :none  ] => [nil              , {foo: false, bar: false, baz: false}], # OK
+        [:none  , :stdout] => [nil              , {foo: true , bar: false, baz: true }], # OK
+        [:none  , :stderr] => [nil              , {foo: false, bar: true , baz: false}], # OK
+        [:none  , :both  ] => [nil              , {foo: true , bar: true , baz: true }], # OK
+        [:stdout, :none  ] => ["foo\nbaz\n"     , {foo: false, bar: false, baz: false}], # OK
         [:stdout, :stdout] => ["foo\nbaz\n"     , {foo: true , bar: false, baz: true }], # BINGO
         [:stdout, :stderr] => ["foo\nbaz\n"     , {foo: false, bar: true , baz: false}], # NOT REALTIME
         [:stdout, :both  ] => ["foo\nbaz\n"     , {foo: true , bar: true , baz: true }], # NOT REALTIME # DEFAULT
-        [:stderr, :nil   ] => ["bar\n"          , {foo: false, bar: false, baz: false}], # OK
+        [:stderr, :none  ] => ["bar\n"          , {foo: false, bar: false, baz: false}], # OK
         [:stderr, :stdout] => ["bar\n"          , {foo: true , bar: false, baz: true }], # NOT REALTIME
         [:stderr, :stderr] => ["bar\n"          , {foo: false, bar: true , baz: false}], # BINGO
         [:stderr, :both  ] => ["bar\n"          , {foo: true , bar: true , baz: true }], # NOT REALTIME
-        [:both  , :nil   ] => ["foo\nbar\nbaz\n", {foo: false, bar: false, baz: false}], # OK
-        [:wrong , :nil   ] => :invalid,
-        [:nil   , :wrong ] => :invalid,
+        [:both  , :none  ] => ["foo\nbar\nbaz\n", {foo: false, bar: false, baz: false}], # OK
+        [:wrong , :none  ] => :invalid,
+        [:none  , :wrong ] => :invalid,
         [:both  , :stdout] => :invalid,
         [:both  , :stderr] => :invalid,
         [:both  , :both  ] => ["foo\nbar\nbaz\n", {foo: true , bar: true , baz: true }], # BINGO


### PR DESCRIPTION
add these 2 options to LoggerPipe.run

```
@option options [Symbol] :returns Which output is used as return, one of :none, :stdout, :stderr, :both
@option options [Symbol] :logging Which output is written to logger, one of :none, :stdout, :stderr, :both
```

In order to be able to control return and logging.
On the one hand output to stdout of query command such as `gcloud compute instances inspect --format json` is too big, but on the other hand output to stdout of command such as `ansible-playbook -vvv` is not used as result but is used as log with stderr.
## reviewers
- [x] @nagachika 
- [x] @minimum2scp 
